### PR TITLE
Introduce execution time limits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ deno_webidl = "0.214.0"
 env_logger = "0.11.5"
 http = "1.3.1"
 log = { version = "0.4.22", features = ["kv"] }
+rand = "0.9.2"
 rustls = "0.23.28"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,6 +1,10 @@
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 export async function handler(req) {
   console.log("Request:", req);
   const who = req.body ? JSON.parse(req.body).name : "World";
+
+  await wait(20000);
 
   return {
     status: 200,

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,10 +1,11 @@
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export async function handler(req) {
-  console.log("Request:", req);
+  // console.log("Request:", req);
   const who = req.body ? JSON.parse(req.body).name : "World";
 
   await wait(20000);
+  // while (true) {}
 
   return {
     status: 200,

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,12 +1,5 @@
-const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
 export async function handler(req) {
-  // console.log("Request:", req);
   const who = req.body ? JSON.parse(req.body).name : "World";
-
-  await wait(20000);
-  // while (true) {}
-
   return {
     status: 200,
     headers: {

--- a/src/runtime/http.rs
+++ b/src/runtime/http.rs
@@ -12,7 +12,7 @@ pub struct Request {
     pub body: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Response {
     pub status: u16,
     pub headers: HashMap<String, String>,

--- a/src/runtime/sandbox.rs
+++ b/src/runtime/sandbox.rs
@@ -7,7 +7,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::LazyLock;
 use std::time::Duration;
-use tokio::time::timeout;
 use uuid::Uuid;
 
 use super::ext;
@@ -62,7 +61,7 @@ impl Sandbox {
         request: http::Request,
         timeout_duration: Duration,
     ) -> Result<http::Response> {
-        let execution_result = timeout(timeout_duration, async {
+        let execution_result = tokio::time::timeout(timeout_duration, async {
             let _ = self
                 .runtime
                 .load_side_es_module_from_code(&USER_MOD_SPECIFIER, user_code)
@@ -85,11 +84,11 @@ impl Sandbox {
                 // completed
             }
             Ok(Err(e)) => {
-                // some error?
+                // an error occurred
                 return Err(e);
             }
             Err(_) => {
-                // timeout
+                // timeout occurred
                 return Err(anyhow!("JavaScript execution timed out"));
             }
         }
@@ -99,75 +98,5 @@ impl Sandbox {
         res.set_runtime_headers(self.state.borrow().request_id);
 
         Ok(res)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::HashMap;
-    use std::time::Duration;
-
-    #[tokio::test]
-    async fn test_execute_timeout() {
-        let request_id = Uuid::new_v4();
-        let mut sandbox = Sandbox::new(request_id).expect("Failed to create sandbox");
-
-        let long_running_code = r#"
-            export default async function handler(request) {
-                await new Promise(resolve => setTimeout(resolve, 1000));
-                return { status: 200, headers: {}, body: "This should timeout" };
-            }
-        "#
-        .to_string();
-
-        let request = http::Request {
-            method: "GET".to_string(),
-            uri: "/".to_string(),
-            headers: HashMap::new(),
-            body: None,
-        };
-
-        let timeout_duration = Duration::from_millis(100);
-
-        let result = sandbox
-            .execute(long_running_code, request, timeout_duration)
-            .await;
-
-        assert!(result.is_err());
-        let error_msg = result.unwrap_err().to_string();
-
-        assert!(error_msg.contains("JavaScript execution timed out"));
-    }
-
-    #[tokio::test]
-    async fn test_execute_success_within_timeout() {
-        let request_id = Uuid::new_v4();
-        let mut sandbox = Sandbox::new(request_id).expect("Failed to create sandbox");
-
-        let simple_code = r#"
-            export default function handler(request) {
-                return { status: 200, headers: {}, body: "Hello, World!" };
-            }
-        "#
-        .to_string();
-
-        let request = http::Request {
-            method: "GET".to_string(),
-            uri: "/".to_string(),
-            headers: HashMap::new(),
-            body: None,
-        };
-
-        let timeout_duration = Duration::from_secs(5);
-
-        let result = sandbox
-            .execute(simple_code, request, timeout_duration)
-            .await;
-
-        assert!(result.is_ok());
-        let response = result.unwrap();
-        assert_eq!(response.status, 200);
-        assert_eq!(response.body, "Hello, World!");
     }
 }

--- a/src/worker/pool.rs
+++ b/src/worker/pool.rs
@@ -1,36 +1,62 @@
 use anyhow::Result;
-use deno_core::JsRuntime;
+use deno_core::{JsRuntime, v8::IsolateHandle};
+use rand::Rng;
+use rand::seq::SliceRandom;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::time::sleep;
 use uuid::Uuid;
 
 use super::worker::{Worker, WorkerRequest, WorkerResponse};
 use crate::runtime::http;
 
+#[derive(Debug)]
+pub enum SupervisorMessage {
+    Store(usize, IsolateHandle, Duration),
+    Release(usize),
+}
+
+struct WorkingWorker {
+    id: usize,
+    handle: IsolateHandle,
+    deadline: tokio::time::Instant,
+}
+
 pub struct Pool {
+    // Senders for worker requests
     worker_txs: Vec<mpsc::UnboundedSender<WorkerRequest>>,
+    // Receiver for worker responses
     responder_rx: Arc<Mutex<mpsc::UnboundedReceiver<WorkerResponse>>>,
+    // Receiver for worker events
+    supervisor_rx: Arc<Mutex<mpsc::UnboundedReceiver<SupervisorMessage>>>,
+    // Requests waiting for workers to do work
     pending_requests: Arc<Mutex<HashMap<Uuid, oneshot::Sender<Result<http::Response, String>>>>>,
-    current_worker_idx: Arc<Mutex<usize>>,
+    // Active workers with attributes and isolate reference
+    current_workers: Arc<Mutex<HashMap<usize, WorkingWorker>>>,
+    // The size of the worker pool
     pool_size: usize,
 }
 
 impl Pool {
     pub fn new(pool_size: usize) -> Self {
         let (responder_tx, responder_rx) = mpsc::unbounded_channel();
+        let (supervisor_tx, supervisor_rx) = mpsc::unbounded_channel();
         let worker_txs = Vec::with_capacity(pool_size);
 
         let mut pool = Self {
             pool_size,
             worker_txs,
             responder_rx: Arc::new(Mutex::new(responder_rx)),
+            supervisor_rx: Arc::new(Mutex::new(supervisor_rx)),
             pending_requests: Arc::new(Mutex::new(HashMap::new())),
-            current_worker_idx: Arc::new(Mutex::new(0)),
+            current_workers: Arc::new(Mutex::new(HashMap::new())),
         };
 
         pool.spawn_reciever();
-        pool.spawn_workers(responder_tx);
+        pool.spawn_supervisor();
+        pool.spawn_workers(responder_tx, supervisor_tx);
         pool
     }
 
@@ -70,7 +96,11 @@ impl Pool {
         }
     }
 
-    fn spawn_workers(&mut self, responder_tx: mpsc::UnboundedSender<WorkerResponse>) {
+    fn spawn_workers(
+        &mut self,
+        responder_tx: mpsc::UnboundedSender<WorkerResponse>,
+        supervisor_tx: mpsc::UnboundedSender<SupervisorMessage>,
+    ) {
         // https://docs.rs/deno_core/0.353.0/deno_core/struct.JsRuntime.html#method.init_platform
         JsRuntime::init_platform(Default::default(), false);
 
@@ -79,6 +109,7 @@ impl Pool {
             self.worker_txs.push(request_tx);
 
             let responder_tx = responder_tx.clone();
+            let supervisor_tx = supervisor_tx.clone();
 
             // each runtime needs its own thread, specifically with tokio's current thread runtime
             std::thread::spawn(move || {
@@ -87,11 +118,65 @@ impl Pool {
                     .build()
                     .unwrap();
                 rt.block_on(async {
-                    let mut worker = Worker::new(i, request_rx, responder_tx);
+                    let mut worker = Worker::new(i, request_rx, responder_tx, supervisor_tx);
                     worker.run().await;
                 });
             });
         }
+    }
+
+    fn spawn_supervisor(&self) {
+        let supervisor_rx = self.supervisor_rx.clone();
+        let current_workers = self.current_workers.clone();
+        tokio::spawn(async move {
+            let mut receiver = supervisor_rx.lock().await;
+
+            loop {
+                tokio::select! {
+                    supervisor_msg = receiver.recv() => {
+                        match supervisor_msg {
+                            Some(SupervisorMessage::Store(worker_id, isolate_handle, duration)) => {
+                                let mut current_workers = current_workers.lock().await;
+                                log::info!(worker_id = worker_id; "Supervisor received isolate handle");
+                                current_workers.insert(worker_id, WorkingWorker {
+                                    id: worker_id,
+                                    handle: isolate_handle,
+                                    deadline: tokio::time::Instant::now() + duration,
+                                });
+                            }
+                            Some(SupervisorMessage::Release(worker_id)) => {
+                                let mut current_workers = current_workers.lock().await;
+                                log::info!(worker_id = worker_id; "Supervisor received release message");
+                                _ = current_workers.remove(&worker_id)
+                            }
+                            None => {
+                                log::info!("Supervisor channel closed");
+                                break;
+                            }
+                        }
+                    }
+
+                    _ = sleep(Duration::from_millis(100)) => {
+                        let now = tokio::time::Instant::now();
+                        let mut to_remove = Vec::new();
+                        let mut current_workers = current_workers.lock().await;
+
+                        for (worker_id, worker) in current_workers.iter() {
+                            if now > worker.deadline {
+                                to_remove.push(*worker_id);
+                            }
+                        }
+
+                        for worker_id in to_remove {
+                            if let Some(worker) = current_workers.remove(&worker_id) {
+                                log::warn!(worker_id = worker.id; "Supervisor terminating isolate (worker_id={}) after deadline", worker.id);
+                                worker.handle.terminate_execution();
+                            }
+                        }
+                    }
+                }
+            }
+        });
     }
 
     fn spawn_reciever(&self) {
@@ -99,13 +184,11 @@ impl Pool {
         let pending_requests = self.pending_requests.clone();
         tokio::spawn(async move {
             let mut receiver = responder_rx.lock().await;
-
             while let Some(response) = receiver.recv().await {
                 let mut pending = pending_requests.lock().await;
-
                 if let Some(sender) = pending.remove(&response.id) {
-                    if let Err(_) = sender.send(response.result) {
-                        log::warn!(request_id:? = response.id; "Failed to send response to waiting request");
+                    if let Err(Err(err)) = sender.send(response.result) {
+                        log::warn!(request_id:? = response.id; "Failed to send response to waiting request: {}", err);
                     }
                 } else {
                     log::warn!(request_id:? = response.id; "Received response for unknown request");
@@ -132,11 +215,31 @@ impl Pool {
         }
     }
 
-    // TODO: find next free worker instead of round robin
+    /// Finds the next free worker index. If all workers are busy, it picks the one with the lowest deadline.
+    /// TODO: this does not currently take into account the initialization time of the sandbox, just executing the modules.
     async fn next_worker_idx(&self) -> usize {
-        let mut current = self.current_worker_idx.lock().await;
-        let idx = *current;
-        *current = (idx + 1) % self.pool_size;
-        idx
+        let mut worker_ids: Vec<usize> = (0..self.pool_size).collect();
+        worker_ids.shuffle(&mut rand::rng());
+        let current_workers = self.current_workers.lock().await;
+
+        let mut candidate = None;
+        for worker_id in worker_ids {
+            match current_workers.get(&worker_id) {
+                Some(worker) => match candidate {
+                    Some((_, min)) => {
+                        if worker.deadline < min {
+                            candidate = Some((worker_id, worker.deadline));
+                        }
+                    }
+                    None => candidate = Some((worker_id, worker.deadline)),
+                },
+                None => return worker_id,
+            }
+        }
+
+        match candidate {
+            Some((worker_id, _)) => worker_id,
+            None => rand::rng().random_range(0..self.pool_size),
+        }
     }
 }

--- a/src/worker/worker.rs
+++ b/src/worker/worker.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -81,7 +82,11 @@ impl Worker {
         };
 
         runtime
-            .execute(request.js_code, request.http_request)
+            .execute(
+                request.js_code,
+                request.http_request,
+                Duration::from_secs(10),
+            )
             .await
             .map_err(|e| format!("handler invocation failed: {}", e))
     }

--- a/src/worker/worker.rs
+++ b/src/worker/worker.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
+use super::pool::SupervisorMessage;
 use crate::runtime::{Sandbox, http};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -19,25 +20,28 @@ pub struct WorkerResponse {
 }
 
 pub struct Worker {
-    pub(crate) id: usize,
-    pub(crate) request_rx: mpsc::UnboundedReceiver<WorkerRequest>,
-    pub(crate) responder_tx: mpsc::UnboundedSender<WorkerResponse>,
+    pub id: usize,
+    pub request_rx: mpsc::UnboundedReceiver<WorkerRequest>,
+    pub responder_tx: mpsc::UnboundedSender<WorkerResponse>,
+    pub supervisor_tx: mpsc::UnboundedSender<SupervisorMessage>,
 }
 
 impl Worker {
-    pub(crate) fn new(
+    pub fn new(
         id: usize,
         request_rx: mpsc::UnboundedReceiver<WorkerRequest>,
         responder_tx: mpsc::UnboundedSender<WorkerResponse>,
+        supervisor_tx: mpsc::UnboundedSender<SupervisorMessage>,
     ) -> Self {
         Self {
             id,
             request_rx,
             responder_tx,
+            supervisor_tx,
         }
     }
 
-    pub(crate) async fn run(&mut self) {
+    pub async fn run(&mut self) {
         log::info!(worker_id = self.id; "Worker {} starting", self.id);
 
         while let Some(request) = self.request_rx.recv().await {
@@ -45,7 +49,7 @@ impl Worker {
             log::info!(
                 worker_id = self.id,
                 request_id:? = request_id;
-                "Worker accepted request"
+                "Worker {} accepted request", self.id
             );
 
             let result = self.process_request(request).await;
@@ -69,7 +73,10 @@ impl Worker {
     }
 
     async fn process_request(&self, request: WorkerRequest) -> Result<http::Response, String> {
-        let mut runtime = match Sandbox::new(request.id) {
+        // TODO: maybe this can be configurable for users depending on their 'trust' level
+        let timeout = Duration::from_secs(30);
+
+        let mut sandbox = match Sandbox::new(request.id) {
             Ok(rt) => rt,
             Err(e) => {
                 log::error!(
@@ -81,13 +88,27 @@ impl Worker {
             }
         };
 
-        runtime
-            .execute(
-                request.js_code,
-                request.http_request,
-                Duration::from_secs(10),
-            )
+        {
+            let handle = sandbox.runtime.v8_isolate().thread_safe_handle();
+            self.notify_supervisor(SupervisorMessage::Store(self.id, handle, timeout));
+        }
+
+        let result = sandbox
+            .execute(request.js_code, request.http_request, timeout)
             .await
-            .map_err(|e| format!("handler invocation failed: {}", e))
+            .map_err(|e| format!("handler invocation failed: {}", e));
+
+        self.notify_supervisor(SupervisorMessage::Release(self.id));
+        result
+    }
+
+    fn notify_supervisor(&self, msg: SupervisorMessage) {
+        if let Err(e) = self.supervisor_tx.send(msg) {
+            log::error!(
+                worker_id = self.id,
+                error:? = e;
+                "Failed to notify supervisor: {e}"
+            );
+        }
     }
 }


### PR DESCRIPTION
This was a fun one.

There's effectively two ways someone can maliciously clog up the workers: either synchronously (while tight/spin loop) or asynchronously with a (e.g. `setTimeout` or otherwise something that prevents the promise from resolving)

For synchronous, I implemented a "supervisor" process in a separate thread (since the worker thread will be effectively blocked since the tokio runtime for workers are current thread scheduled). The workers get a sender where a task in the main pool thread will accept the worker's thread-safe isolate handle, and a deadline. Every ~100ms it will check if the deadline is up for any workers and call `v8::Isolate::TerminateExecution`.

In addition, now that we are aware of what workers are "doing work" and when they'll be up, I moved away from the round robin selection to instead pick either the first worker that isn't tracked doing work or the worker with the lowest deadline. It'll also do a quick shuffle of all the worker IDs for a bit of random selection.