### PR TITLE
Add 64MB heap limit

### DIFF
--- a/examples/big_heap.js
+++ b/examples/big_heap.js
@@ -1,0 +1,51 @@
+function startEatingHeapMemory() {
+  const arrays = [];
+  const chunkSize = 1024 * 1024;
+  let totalAllocated = 0;
+
+  console.log("Starting heap limit test - allocating memory in chunks...");
+
+  while (true) {
+    const chunk = new Array(chunkSize / 8);
+    for (let i = 0; i < chunk.length; i++) {
+      chunk[i] = Math.random();
+    }
+    arrays.push(chunk);
+    totalAllocated += chunkSize;
+
+    console.log(`Allocated: ${(totalAllocated / (1024 * 1024)).toFixed(2)} MB`);
+
+    if (totalAllocated > 100 * 1024 * 1024) {
+      arrays.push(JSON.stringify(arrays));
+    }
+  }
+}
+
+function takeABigByte() {
+  console.log("Attempting to allocate a single large array...");
+  const hugeArray = new Array((1024 * 1024 * 1024) / 8);
+  for (let i = 0; i < hugeArray.length; i++) {
+    hugeArray[i] = i;
+  }
+  console.log("Successfully allocated");
+}
+
+export async function handler(req) {
+  switch (req.uri) {
+    case "/gradual":
+      startEatingHeapMemory();
+      break;
+    case "/at-once":
+      takeABigByte();
+      break;
+    default:
+      return {
+        status: 404,
+        body: "Either /gradual or /at-once",
+      };
+  }
+
+  return {
+    status: 200,
+  };
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -14,7 +14,7 @@ use crate::workers;
 pub async fn invoke(State(pool): State<Arc<workers::Pool>>, request: Request) -> Response {
     // TODO: temporary, eventually this should be served dynamically
     // possibly serve https://github.com/denoland/eszip
-    let js_code = include_str!("../examples/basic.js");
+    let js_code = include_str!("../examples/big_heap.js");
 
     let method = request.method().to_string();
     let uri = request.uri().to_string();

--- a/src/runtime/js/worker.js
+++ b/src/runtime/js/worker.js
@@ -29,7 +29,11 @@ async function worker() {
       throw new Error("invalid response");
     }
 
-    return res;
+    return {
+      status: res.status || 200,
+      headers: res.headers || {},
+      body: res.body || "",
+    };
   } catch (error) {
     const msg = error && error.message ? error.message : String(error);
     console.log(`Error: ${msg}`);


### PR DESCRIPTION
This sets the isolate's heap limit to 64MB. If an isolate approaches this heap limit, it'll call [`AddNearHeapLimitCallback`](https://v8.github.io/api/head/classv8_1_1Isolate.html#ae6fc7e1186beb40707180dd58456f741) and we'll artificially bump the memory so it doesn't crash the whole process.

Unfortunately this isn't bulletproof, but a decent starting point. An OOM for v8 will crash the whole process, which can harm shared threads.