### PR TITLE
Create startup snapshots at build time

### DIFF
--- a/crates/funcgg-runtime/src/lib.rs
+++ b/crates/funcgg-runtime/src/lib.rs
@@ -3,4 +3,5 @@ mod loader;
 mod sandbox;
 
 pub mod http;
+pub mod snapshot;
 pub use sandbox::Sandbox;

--- a/crates/funcgg-runtime/src/sandbox.rs
+++ b/crates/funcgg-runtime/src/sandbox.rs
@@ -35,7 +35,7 @@ pub struct Sandbox {
 }
 
 impl Sandbox {
-    pub fn new(request_id: Uuid) -> Result<Self> {
+    pub fn new(request_id: Uuid, startup_snapshot: Option<&'static [u8]>) -> Result<Self> {
         _ = CryptoProvider::install_default(aws_lc_rs::default_provider());
 
         let state = Rc::new(RefCell::new(State {
@@ -47,12 +47,12 @@ impl Sandbox {
         let create_params = v8::CreateParams::default().heap_limits(0, HEAP_LIMIT);
 
         let mod_loader = Rc::new(loader::ModuleLoader::new());
-        // TODO: snapshotting???
         let mut runtime = JsRuntime::try_new(RuntimeOptions {
             module_loader: Some(mod_loader),
             extensions: ext::extensions(),
             extension_transpiler: Some(extension_transpiler),
             create_params: Some(create_params),
+            startup_snapshot,
             ..Default::default()
         })?;
 

--- a/crates/funcgg-runtime/src/snapshot.rs
+++ b/crates/funcgg-runtime/src/snapshot.rs
@@ -1,0 +1,25 @@
+use deno_core::snapshot::CreateSnapshotOutput;
+use std::env;
+use std::rc::Rc;
+
+use super::ext;
+use crate::loader;
+
+pub const FILE_NAME: &str = "FUNCGG_RUNTIME_SNAPSHOT.bin";
+
+pub fn build() -> anyhow::Result<CreateSnapshotOutput> {
+    let extension_transpiler = Rc::new(loader::transpile);
+    let snapshot = deno_core::snapshot::create_snapshot(
+        deno_core::snapshot::CreateSnapshotOptions {
+            cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
+            startup_snapshot: None,
+            skip_op_registration: false,
+            extensions: ext::extensions(),
+            extension_transpiler: Some(extension_transpiler),
+            with_runtime_cb: None,
+        },
+        None,
+    )?;
+
+    Ok(snapshot)
+}

--- a/crates/funcgg-worker/Cargo.toml
+++ b/crates/funcgg-worker/Cargo.toml
@@ -23,3 +23,6 @@ tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
+
+[build-dependencies]
+funcgg-runtime = { path = "../funcgg-runtime" }

--- a/crates/funcgg-worker/build.rs
+++ b/crates/funcgg-worker/build.rs
@@ -11,6 +11,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("cargo:rerun-if-changed={}", file.display());
     }
 
-    std::fs::write(out_dir.join("FUNCGG_RUNTIME_SNAPSHOT.bin"), snapshot.output)?;
+    let snapshot_path = out_dir.join(funcgg_runtime::snapshot::FILE_NAME);
+    std::fs::write(snapshot_path.clone(), snapshot.output)?;
+    println!("cargo:rustc-env=SNAPSHOT_PATH={}", snapshot_path.display());
     Ok(())
 }

--- a/crates/funcgg-worker/build.rs
+++ b/crates/funcgg-worker/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=build.rs");
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+    let snapshot = funcgg_runtime::snapshot::build()?;
+
+    println!("cargo:rerun-if-changed=../funcgg-runtime/src");
+    for file in snapshot.files_loaded_during_snapshot {
+        println!("cargo:rerun-if-changed={}", file.display());
+    }
+
+    std::fs::write(out_dir.join("FUNCGG_RUNTIME_SNAPSHOT.bin"), snapshot.output)?;
+    Ok(())
+}

--- a/crates/funcgg-worker/src/workers/worker.rs
+++ b/crates/funcgg-worker/src/workers/worker.rs
@@ -6,6 +6,9 @@ use uuid::Uuid;
 use super::pool::StateChange;
 use funcgg_runtime::{Sandbox, http};
 
+static STARTUP_SNAPSHOT: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/FUNCGG_RUNTIME_SNAPSHOT.bin"));
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerRequest {
     pub id: Uuid,
@@ -56,7 +59,7 @@ impl Worker {
     }
 
     async fn process_request(&self, request: WorkerRequest) -> Result<http::Response, String> {
-        let mut sandbox = match Sandbox::new(request.id) {
+        let mut sandbox = match Sandbox::new(request.id, Some(STARTUP_SNAPSHOT)) {
             Ok(rt) => rt,
             Err(e) => {
                 tracing::error!(

--- a/crates/funcgg-worker/src/workers/worker.rs
+++ b/crates/funcgg-worker/src/workers/worker.rs
@@ -6,8 +6,7 @@ use uuid::Uuid;
 use super::pool::StateChange;
 use funcgg_runtime::{Sandbox, http};
 
-static STARTUP_SNAPSHOT: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/FUNCGG_RUNTIME_SNAPSHOT.bin"));
+static STARTUP_SNAPSHOT: &[u8] = include_bytes!(env!("SNAPSHOT_PATH"));
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerRequest {


### PR DESCRIPTION
This gives a nice start boost. I took a sample of "hello world" requests to compare timings from request received to isolate initialized. These timings do not include the actual runtime of the user code.

Before startup snapshot:

```
min: 44.461708ms, max: 75.167375ms, avg: 52.93726154385965ms
```

After snapshotting:

```
min: 7.710125ms, max: 23.561291ms, avg: 11.90164068888889ms
```